### PR TITLE
Feature/ledgers patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,16 @@ This FastAPI project is for test
 3. 메모 (note)
 4. event_date (거래 발생 날짜)
 5. created_at (ledger 생성 날짜)
+
+
+### API docs
+- Swagger를 적극 활용해 따로 작성할 필요가 없고 서버만 실행 하면 쉽게 확인할 수 있어 용이하다..
+
+### 가계부 API
+- 가계부 내역 리스트
+- 가계부 내역 생성
+- 가계부 내역 수정 `PATCH /ledger/id`
+- 가계부 내역 상세 조회 `GET /ledger/id`
+- 가계부 내역 삭제 `DELETE /ledger/id`
+- 가계부 내역 복제 `POST /ledger/id`
+- 가계부 내역 공유 URL -> 토큰 확인

--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
 # fastapi_test
 This FastAPI project is for test
 
-### 코딩 컨벤션
-- 처음 router의 method 이름을 `signin`, `signup`으로 했지만 이런 경우 일관성을 지키기 어려울 듯 하여 `post_user_signin`과 같이 **http method 명 + method가 어떤 기능을 하는 지를** 나타낼 수 있도록 수정했다.
+### 코딩 컨벤션 및 네이밍 고민
+- 처음 router의 method 이름을 `signin`, `signup`으로 했지만 
+이런 경우 일관성을 지키기 어려울 듯 하여 `post_user_signin`과 같이 **http method 명 + method가 어떤 기능을 하는 지를** 나타낼 수 있도록 수정했다.
+- ledger는 장부란 뜻이 있기 때문에 router을 ledger로 지었지만 
+거래내역을 CRUD하는 경우 ledger란 단어는 어울리지 않는다고 생각했다.
+그래서 `/ledger/transaction/{transaction_id}`와 같이 transaction이 ledger에 속하게끔 수정했다.
+table 명의 경우 Ledger이기 때문에 논리적으론 맞지만 Ledger 각 row들은 ledger가 아닌 transaction이므로 
+Ledger 객체를 반환시 이름이 서로 맞지 않는 문제가 있다.  
 
 ### 가계부에 들어갈 요소
 1. 수입/지출 (amount)

--- a/crud/ledger.py
+++ b/crud/ledger.py
@@ -17,3 +17,28 @@ def create_transaction(
     db.refresh(transaction_obj)
 
     return transaction_obj
+
+
+def read_transaction(
+    transaction_id: int,
+    user_id       : int,
+    db            : Session
+) -> Ledger:
+    transaction = db.query(Ledger).filter(
+            Ledger.id == transaction_id,
+            Ledger.author_id == user_id
+    )
+
+    return transaction.first()
+
+
+def update_transaction(
+    transaction_id: int,
+    req_data      : ledger_schema.TransactionUpdate,
+    db            : Session
+) -> Ledger:
+    is_updated = db.query(Ledger).filter(Ledger.id == transaction_id).update(req_data.dict(exclude_unset=True))
+
+    db.commit()
+
+    return is_updated

--- a/database/models.py
+++ b/database/models.py
@@ -23,7 +23,7 @@ class Ledger(Base, PrimaryKey):
 
     author_id  = Column(Integer, ForeignKey('users.id', ondelete='CASCADE'))
     author     = relationship('User', back_populates='ledgers')
-    item       = Column(String(255))
+    item_name  = Column(String(255))
     note       = Column(Text())
     amount     = Column(Integer(), nullable=False)
     event_date = Column(DateTime())  # 거래 발생 날짜

--- a/routers/ledger.py
+++ b/routers/ledger.py
@@ -18,16 +18,39 @@ authentication_responses = {
     401: {"model": Message, "description": "무효한 토큰"},
 }
 
+ledger_responses = {
+    401: {"model": Message, "description": "무효한 토큰"},
+    404: {"model": Message, "description": "거래 내역 없음"},
+}
 
-@router.post("", status_code=status.HTTP_201_CREATED, responses=authentication_responses)
+
+@router.post("/transaction", status_code=status.HTTP_201_CREATED, responses=authentication_responses)
 def post_transaction(
     transaction_data: ledger_schema.TransactionCreate,
     user            : User = Depends(get_logged_in_user),
     db               : Session = Depends(get_db)
 ):
     transaction_data.author_id = user.id
-    transaction_data.event_date = datetime.strptime(transaction_data.event_date, '%Y-%m-%d')
+    transaction_data.event_date = datetime.strptime(transaction_data.event_date, '%Y-%m-%d %H:%M:%S.%f')
 
     ledger_crud.create_transaction(transaction_data, db)
 
     return JSONResponse(status_code=201, content={"message": "내역 생성 성공"})
+
+
+@router.patch("/transaction/{transaction_id}", status_code=status.HTTP_200_OK, responses=ledger_responses)
+def patch_transaction(
+    transaction_id  : int,
+    transaction_data: ledger_schema.TransactionUpdate,
+    user            : User = Depends(get_logged_in_user),
+    db              : Session = Depends(get_db)
+):
+    transaction = ledger_crud.read_transaction(transaction_id, user.id, db)
+
+    if not transaction:
+        return JSONResponse(status_code=404, content={"message": "내역 없음"})
+
+    transaction_data.event_date = datetime.strptime(transaction_data.event_date, '%Y-%m-%d %H:%M:%S.%f')
+    is_updated = ledger_crud.update_transaction(transaction.id, transaction_data, db)
+
+    return is_updated

--- a/schemas/ledger.py
+++ b/schemas/ledger.py
@@ -6,7 +6,15 @@ from pydantic import BaseModel
 
 class TransactionCreate(BaseModel):
     author_id : Optional[int]
-    item      : Optional[str]
+    item_name : Optional[str]
     note      : Optional[str]
     amount    : int
+    event_date: Union[str, datetime]
+
+
+class TransactionUpdate(BaseModel):
+    author_id : Optional[int]
+    item_name : Optional[str]
+    note      : Optional[str]
+    amount    : Optional[int]
     event_date: Union[str, datetime]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ import pytest
 
 from main            import app
 from routers.deps    import get_db
-from database.models import Base, User
+from database.models import Base, User, Ledger
 from core.auth       import get_password_hashed, create_access_token
 
 
@@ -58,3 +58,17 @@ def get_user_token():
     db.refresh(user_obj)
 
     return {"Authorization": create_access_token(user_obj.id)}
+
+
+def get_user_by_id():
+    user = db.query(User).filter(User.username == "token@email.com").first()
+
+    return user
+
+
+def get_transaction():
+    user = get_user_by_id()
+
+    ledger = db.query(Ledger.id).filter(Ledger.author_id == user.id).first()
+
+    return ledger

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -1,23 +1,61 @@
 from datetime import datetime
 
-from tests.conftest  import client, get_user_token
+import pytest
+
+from tests.conftest  import client, get_user_token, TestingSessionLocal, get_user_by_id, get_transaction
+from database.models import Ledger
 
 
 token_header = get_user_token()
+db = TestingSessionLocal()
 
 
-def test_create_ledger():
-    ledger_data = {
-        "item": "꽤나 큰 지출",
-        "note": "너무 큰 지출을 해버렸다!",
-        "amount": -1000000,
-        "event_date": str(datetime.now().date())
+@pytest.fixture(scope='module', autouse=True)
+def create_transaction():
+    user = get_user_by_id()
+
+    transaction_obj = Ledger(
+        author_id =user.id,
+        item_name ="테스트 아이템",
+        note      ="테스트 노트",
+        amount    =1000000,
+        event_date=datetime.today(),
+    )
+
+    db.add(transaction_obj)
+    db.commit()
+
+
+def test_create_transaction():
+    transaction_data = {
+        "item_name" : "꽤나 큰 지출",
+        "note"      : "너무 큰 지출을 해버렸다!",
+        "amount"    : -1000000,
+        "event_date": str(datetime.now())
     }
 
     response = client.post(
-        "/ledger",
-        json=ledger_data,
+        "/ledger/transaction",
+        json=transaction_data,
         headers=token_header
     )
 
     assert response.status_code == 201
+
+
+def test_update_transaction():
+    transaction_data = {
+        "item_name": "꽤나 작은 지출",
+        "amount": -1000,
+        "event_date": str(datetime.now())
+    }
+
+    transaction = get_transaction()
+
+    response = client.patch(
+        f"/ledger/transaction/{transaction.id}",
+        json=transaction_data,
+        headers=token_header
+    )
+
+    assert response.status_code == 200


### PR DESCRIPTION
- 거래내역 수정 API 추가
- 가계부-거래내역 관계 표시를 위해 거래내역 관련 API url `/ledger` -> `/ledger/transaction`으로 수정 
- Ledger 테이블의 컬럼명 `item`을 뜻이 좀 더 분명한 `item_name`으로 변경